### PR TITLE
Fix script line breaking when changing wallpaper

### DIFF
--- a/change_wallpaper_reddit.py
+++ b/change_wallpaper_reddit.py
@@ -121,8 +121,7 @@ def detect_desktop_environment():
     if os.environ.get("KDE_FULL_SESSION") == "true":
         environment["name"] = "kde"
         environment["command"] = """
-                    qdbus org.kde.plasmashell /PlasmaShell
-                    org.kde.PlasmaShell.evaluateScript '
+                    qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript '
                         var allDesktops = desktops();
                         print (allDesktops);
                         for (i=0;i<allDesktops.length;i++) {{


### PR DESCRIPTION
The bash command that is being invoked when setting wallpaper had wrong
line breaking which caused a qdbus to think that it was called without
method name, hence the information in bug report.

Closes #23
