### PR TITLE
Added support for unicode save_location on windows and python 2

### DIFF
--- a/change_wallpaper_reddit.py
+++ b/change_wallpaper_reddit.py
@@ -215,7 +215,10 @@ if __name__ == '__main__':
                 ctypes.windll.user32.SystemParametersInfoW(20, 0, save_location, 3)
             # Python 2.x
             else:
-                ctypes.windll.user32.SystemParametersInfoA(20, 0, save_location, 3)
+                if isinstance(save_location, str):
+                    ctypes.windll.user32.SystemParametersInfoA(20, 0, save_location, 3)
+                else:
+                    ctypes.windll.user32.SystemParametersInfoW(20, 0, save_location, 3)
 
         # OS X/macOS
         if platform_name.startswith("Darwin"):


### PR DESCRIPTION
I am running windows 10 and python 2. For me the save_location variable seems to be unicode, not str. This uses the correct SystemParametersInfoW function in the case when it is unicode. 