### PR TITLE
Skip posts where a URL can't be found

### DIFF
--- a/change_wallpaper_reddit.py
+++ b/change_wallpaper_reddit.py
@@ -100,14 +100,18 @@ def get_top_image(sub_reddit):
         # Strip trailing arguments (after a '?')
         url = re.sub(R"\?.*", "", url)
         ret['type'] = url.split(".")[-1]
+
         if url.endswith(".jpg") or url.endswith(".png"):
             ret["url"] = url
         # Imgur support
-        if ("imgur.com" in url) and ("/a/" not in url) and ("/gallery/" not in url):
+        elif ("imgur.com" in url) and ("/a/" not in url) and ("/gallery/" not in url):
             if url.endswith("/new"):
                 url = url.rsplit("/", 1)[0]
             id = url.rsplit("/", 1)[1].rsplit(".", 1)[0]
             ret["url"] = "http://i.imgur.com/{id}.jpg".format(id=id)
+        else:
+            continue
+
         return ret
 
 


### PR DESCRIPTION
The current top post in r/wallpapers is an animated wallpaper (https://www.reddit.com/r/wallpapers/comments/bysef0/in_light_of_the_release_date_reveal_here_is_my/)

This script is failing for me due to that. This extra check makes it skip to the second post instead of returning a result that doesn't actually have an image URL